### PR TITLE
removed 'public' prefix

### DIFF
--- a/webseed/amoy.toml
+++ b/webseed/amoy.toml
@@ -1,5 +1,5 @@
-"caplin-pub" = "v1:https://public-caplin-snapshots-amoy.erigon.network"
-"erigon-v2-pub" = "v1:https://public-erigon-v2-snapshots-amoy.erigon.network"
+"caplin-pub" = "v1:https://caplin-snapshots-amoy.erigon.network"
+"erigon-v2-pub" = "v1:https://erigon-v2-snapshots-amoy.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-amoy.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-amoy.erigon.network"
 "e3-v1-pub" = "v1:https://erigon3-v1-snapshots-amoy.erigon.network"

--- a/webseed/bor-mainnet.toml
+++ b/webseed/bor-mainnet.toml
@@ -1,5 +1,5 @@
-"caplin-pub" = "v1:https://public-caplin-snapshots-bor-mainnet.erigon.network"
-"erigon-v2-pub" = "v1:https://public-erigon-v2-snapshots-bor-mainnet.erigon.network"
+"caplin-pub" = "v1:https://caplin-snapshots-bor-mainnet.erigon.network"
+"erigon-v2-pub" = "v1:https://erigon-v2-snapshots-bor-mainnet.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-bor-mainnet.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-bor-mainnet.erigon.network"
 "e3-v1-pub" = "v1:https://erigon3-v1-snapshots-bor-mainnet.erigon.network"

--- a/webseed/chiado.toml
+++ b/webseed/chiado.toml
@@ -1,5 +1,5 @@
-"caplin-pub" = "v1:https://public-caplin-snapshots-chiado.erigon.network"
-"erigon-v2-pub" = "v1:https://public-erigon-v2-snapshots-chiado.erigon.network"
+"caplin-pub" = "v1:https://caplin-snapshots-chiado.erigon.network"
+"erigon-v2-pub" = "v1:https://erigon-v2-snapshots-chiado.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-chiado.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-chiado.erigon.network"
 "e3-v1-pub" = "v1:https://erigon3-v1-snapshots-chiado.erigon.network"

--- a/webseed/gnosis.toml
+++ b/webseed/gnosis.toml
@@ -1,5 +1,5 @@
-"caplin-pub" = "v1:https://public-caplin-snapshots-gnosis.erigon.network"
-"erigon-v2-pub" = "v1:https://public-erigon-v2-snapshots-gnosis.erigon.network"
+"caplin-pub" = "v1:https://caplin-snapshots-gnosis.erigon.network"
+"erigon-v2-pub" = "v1:https://erigon-v2-snapshots-gnosis.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-gnosis.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-gnosis.erigon.network"
 "e3-v1-pub" = "v1:https://erigon3-v1-snapshots-gnosis.erigon.network"

--- a/webseed/goerli.toml
+++ b/webseed/goerli.toml
@@ -1,5 +1,5 @@
-"caplin-pub" = "v1:https://public-caplin-snapshots-goerli.erigon.network"
-"erigon-v2-pub" = "v1:https://public-erigon-v2-snapshots-goerli.erigon.network"
+"caplin-pub" = "v1:https://caplin-snapshots-goerli.erigon.network"
+"erigon-v2-pub" = "v1:https://erigon-v2-snapshots-goerli.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-goerli.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-goerli.erigon.network"
 "e3-v1-pub" = "v1:https://erigon3-v1-snapshots-goerli.erigon.network"

--- a/webseed/holesky.toml
+++ b/webseed/holesky.toml
@@ -1,5 +1,5 @@
 "caplin-pub" = "v1:https://caplin-snapshots-holesky.erigon.network"
-"erigon-v2-pub" = "v1:https://public-erigon-v2-snapshots-holesky.erigon.network"
+"erigon-v2-pub" = "v1:https://erigon-v2-snapshots-holesky.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-holesky.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-holesky.erigon.network"
 "e3-v1-pub" = "v1:https://erigon3-v1-snapshots-holesky.erigon.network"

--- a/webseed/mainnet.toml
+++ b/webseed/mainnet.toml
@@ -1,5 +1,5 @@
 "caplin-pub" = "v1:https://caplin-snapshots-mainnet.erigon.network"
-"erigon-v2-pub" = "v1:https://public-erigon-v2-snapshots-mainnet.erigon.network"
+"erigon-v2-pub" = "v1:https://erigon-v2-snapshots-mainnet.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-mainnet.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-mainnet.erigon.network"
 "e3-v1-pub" = "v1:https://erigon3-v1-snapshots-mainnet.erigon.network"

--- a/webseed/mumbai.toml
+++ b/webseed/mumbai.toml
@@ -1,4 +1,4 @@
-"caplin-pub" = "v1:https://public-caplin-snapshots-mumbai.erigon.network"
+"caplin-pub" = "v1:https://caplin-snapshots-mumbai.erigon.network"
 "erigon-v2-pub" = "v1:https://erigon-v2-snapshots-mumbai.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-mumbai.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-mumbai.erigon.network"

--- a/webseed/sepolia.toml
+++ b/webseed/sepolia.toml
@@ -1,5 +1,5 @@
 "caplin-pub" = "v1:https://caplin-snapshots-sepolia.erigon.network/"
-"erigon-v2-pub" = "v1:https://public-erigon-v2-snapshots-sepolia.erigon.network"
+"erigon-v2-pub" = "v1:https://erigon-v2-snapshots-sepolia.erigon.network"
 "e2-v1-pub" = "v1:https://erigon2-v1-snapshots-sepolia.erigon.network"
 "e2-v3-pub" = "v1:https://erigon2-v3-snapshots-sepolia.erigon.network"
 "e3-v1-pub" = "v1:https://erigon3-v1-snapshots-sepolia.erigon.network"


### PR DESCRIPTION
Removed 'public' prefix from v2 (i.e. Mark's) public buckets (and from some Caplin's public buckets too).