### PR TITLE
webseed/bloatnet: point at erigon36-v1 bucket

### DIFF
--- a/webseed/bloatnet.toml
+++ b/webseed/bloatnet.toml
@@ -1,1 +1,1 @@
-"e3-v1-pub" = "v1:https://erigon34-v1-snapshots-bloatnet.erigon.network"
+"e3-v1-pub" = "v1:https://erigon36-v1-snapshots-bloatnet.erigon.network"


### PR DESCRIPTION
Update the bloatnet webseed URL to the new `erigon36-v1-snapshots-bloatnet` R2 bucket for the 3.6 release line.

Companion to erigontech/erigon#21295.