### PR TITLE
webseed: point mainnet/sepolia/chiado/gnosis/hoodi at erigon36-v1 buckets

### DIFF
--- a/webseed/chiado.toml
+++ b/webseed/chiado.toml
@@ -1,1 +1,1 @@
-"e3-v1-pub" = "v1:https://erigon34-v1-snapshots-chiado.erigon.network"
+"e3-v1-pub" = "v1:https://erigon36-v1-snapshots-chiado.erigon.network"

--- a/webseed/gnosis.toml
+++ b/webseed/gnosis.toml
@@ -1,1 +1,1 @@
-"e3-v1-pub" = "v1:https://erigon34-v1-snapshots-gnosis.erigon.network"
+"e3-v1-pub" = "v1:https://erigon36-v1-snapshots-gnosis.erigon.network"

--- a/webseed/hoodi.toml
+++ b/webseed/hoodi.toml
@@ -1,1 +1,1 @@
-"e3-v1-pub" = "v1:https://erigon34-v1-snapshots-hoodi.erigon.network"
+"e3-v1-pub" = "v1:https://erigon36-v1-snapshots-hoodi.erigon.network"

--- a/webseed/mainnet.toml
+++ b/webseed/mainnet.toml
@@ -1,1 +1,1 @@
-"e3-v1-pub" = "v1:https://erigon34-v1-snapshots-mainnet.erigon.network"
+"e3-v1-pub" = "v1:https://erigon36-v1-snapshots-mainnet.erigon.network"

--- a/webseed/sepolia.toml
+++ b/webseed/sepolia.toml
@@ -1,1 +1,1 @@
-"e3-v1-pub" = "v1:https://erigon34-v1-snapshots-sepolia.erigon.network"
+"e3-v1-pub" = "v1:https://erigon36-v1-snapshots-sepolia.erigon.network"


### PR DESCRIPTION
Update webseed URLs for mainnet, sepolia, chiado, gnosis, and hoodi to the new \`erigon36-v1-snapshots-*\` R2 buckets for the 3.6 release line. Follow-up to #1280 which did the same for bloatnet.

The arb chains (\`arb1\`, \`arb-sepolia\`) use a different naming scheme (\`erigon3-v1-snapshots-*\`) and are left unchanged.